### PR TITLE
flip bits, flip words, rename

### DIFF
--- a/sol/dmap.sol
+++ b/sol/dmap.sol
@@ -14,9 +14,10 @@ contract Dmap {
     bytes32 immutable FLAG_LOCK = bytes32(uint256(1 << 255));
 
     constructor(address rootzone) {
+        bytes32 LOCK = FLAG_LOCK;
         assembly {
             sstore(0, shl(96, rootzone))
-            sstore(1, shl(3, 254)) // FLAG_LOCK && FLAG_1
+            sstore(1, LOCK)
         }
     }
 
@@ -39,18 +40,16 @@ contract Dmap {
         }
     }
 
-    error LOCK();
-    bytes4 constant locksel = 0xa4f0d7d0; // keccak256("LOCK()")
     function set(bytes32 name, bytes32 meta, bytes32 data) external {
-        bytes32 _FLAG_LOCK = FLAG_LOCK; // assembly access not supported
+        bytes32 LOCK = FLAG_LOCK;
         assembly {
             log4(0, 0, caller(), name, data, meta)
             mstore(32, name)
             mstore(0, caller())
             let slot0 := keccak256(0, 64)
             let slot1 := add(slot0, 1)
-            if and(_FLAG_LOCK, sload(slot1)) {
-                mstore(0, locksel)
+            if and(LOCK, sload(slot1)) {
+                mstore(0, "LOCK")
                 revert(0, 4)
             }
             sstore(slot0, data)

--- a/sol/dmap.sol
+++ b/sol/dmap.sol
@@ -6,7 +6,7 @@
 pragma solidity 0.8.11;
 
 contract Dmap {
-    // storage: hash(zone, name) -> (data, meta)
+    // storage: hash(zone, name) -> (meta, data)
     // flags: locked (2^0) & appflags
     // log4: zone, key, value, flags
     // err: "LOCK"
@@ -21,7 +21,7 @@ contract Dmap {
     }
 
     function raw(bytes32 slot) external view
-      returns (bytes32 data, bytes32 meta) {
+      returns (bytes32 meta, bytes32 data) {
         assembly {
             meta := sload(add(slot, 1))
             data := sload(slot)
@@ -29,7 +29,7 @@ contract Dmap {
     }
 
     function get(address zone, bytes32 name) external view
-      returns (bytes32 data, bytes32 meta) {
+      returns (bytes32 meta, bytes32 data) {
         assembly {
             mstore(0, zone)
             mstore(32, name)
@@ -41,7 +41,7 @@ contract Dmap {
 
     error LOCK();
     bytes4 constant locksel = 0xa4f0d7d0; // keccak256("LOCK()")
-    function set(bytes32 name, bytes32 data, bytes32 meta) external {
+    function set(bytes32 name, bytes32 meta, bytes32 data) external {
         bytes32 _FLAG_LOCK = FLAG_LOCK; // assembly access not supported
         assembly {
             log4(0, 0, caller(), name, data, meta)

--- a/sol/free.sol
+++ b/sol/free.sol
@@ -24,13 +24,13 @@ contract FreeZone {
     }
 
     function give(bytes32 key, address recipient) external {
-        require(controllers[key] == msg.sender, "ERR_GIVE");
+        require(controllers[key] == msg.sender, "ERR_OWNER");
         controllers[key] = recipient;
         emit Give(msg.sender, key, recipient);
     }
 
-    function set(bytes32 key, bytes32 value, bytes32 flags) external {
-        require(controllers[key] == msg.sender, "ERR_SET");
-        dmap.set(key, value, flags);
+    function set(bytes32 key, bytes32 meta, bytes32 data) external {
+        require(controllers[key] == msg.sender, "ERR_OWNER");
+        dmap.set(key, meta, data);
     }
 }

--- a/sol/root.sol
+++ b/sol/root.sol
@@ -7,11 +7,11 @@ import { Dmap } from './dmap.sol';
 contract RootZone {
     Dmap    public immutable dmap;
     uint256 public           last;
-    bytes32 public           park;
+    bytes32 public           mark;
     uint256        immutable FREQ = 31 hours;
     bytes32        immutable LOCK = bytes32(uint256(1 << 255));
 
-    event Mark(bytes32 indexed hash);
+    event Hark(bytes32 indexed hash);
     event Etch(bytes32 indexed name, address indexed zone);
 
     error ErrPending();
@@ -29,19 +29,19 @@ contract RootZone {
         emit Etch('root', address(this));
     }
 
-    function mark(bytes32 hash) external payable {
+    function hark(bytes32 hash) external payable {
         if (block.timestamp < last + FREQ) revert ErrPending();
         if (msg.value != 1 ether) revert ErrPayment();
         (bool ok, ) = block.coinbase.call{value:(10**18)}("");
         if (!ok) revert ErrReceipt();
         last = block.timestamp;
-        park = hash;
-        emit Mark(hash);
+        mark = hash;
+        emit Hark(hash);
     }
 
     function etch(bytes32 salt, bytes32 name, address zone) external {
         bytes32 hash = keccak256(abi.encode(salt, name, zone));
-        if (hash != park) revert ErrExpired();
+        if (hash != mark) revert ErrExpired();
         dmap.set(name, bytes32(bytes20(zone)), LOCK);
         emit Etch(name, zone);
     }

--- a/task/deploy-mock-dmap.js
+++ b/task/deploy-mock-dmap.js
@@ -9,8 +9,8 @@ task('deploy-mock-dmap', async (args, hh)=> {
     const dmap_type = await hh.artifacts.readArtifact('Dmap')
     const dmap_deployer = await hh.ethers.getContractFactory('Dmap')
 
-    const root_type = await hh.artifacts.readArtifact('DmapRootZone')
-    const root_deployer = await hh.ethers.getContractFactory('DmapRootZone')
+    const root_type = await hh.artifacts.readArtifact('RootZone')
+    const root_deployer = await hh.ethers.getContractFactory('RootZone')
 
     const free_type = await hh.artifacts.readArtifact('FreeZone')
     const free_deployer = await hh.ethers.getContractFactory('FreeZone')
@@ -45,7 +45,7 @@ task('deploy-mock-dmap', async (args, hh)=> {
     // put everything else in a 'full' pack
     await pb.packObject({
         objectname: 'rootzone',
-        typename: 'DmapRootZone',
+        typename: 'RootZone',
         address: tx_root.address,
         artifact: root_type
     }, alsoPackType=true)
@@ -62,7 +62,8 @@ task('deploy-mock-dmap', async (args, hh)=> {
     const show =(o)=> JSON.stringify(o, null, 2)
 
     fs.writeFileSync(packdir + `Dmap.json`, show(dmap_type))
-    fs.writeFileSync(packdir + `DmapRootZone.json`, show(root_type))
+    fs.writeFileSync(packdir + `RootZone.json`, show(root_type))
+    fs.writeFileSync(packdir + `FreeZone.json`, show(root_type))
 
     fs.writeFileSync(packdir + `dmap_core_${hh.network.name}.dpack.json`, show(corepack))
     fs.writeFileSync(packdir + `dmap_full_${hh.network.name}.dpack.json`, show(fullpack))

--- a/task/deploy-mock-dmap.js
+++ b/task/deploy-mock-dmap.js
@@ -28,7 +28,7 @@ task('deploy-mock-dmap', async (args, hh)=> {
     const types = [ "bytes32", "bytes32", "address" ]
     const encoded = ethers.utils.defaultAbiCoder.encode(types, [ salt, name, zone ])
     const commitment = hh.ethers.utils.keccak256(encoded)
-    await send(tx_root.mark, commitment, { value: ethers.utils.parseEther('1') })
+    await send(tx_root.hark, commitment, { value: ethers.utils.parseEther('1') })
     await send(tx_root.etch, salt, name, zone)
 
     const pb = await dpack.builder(hh.network.name)

--- a/test/root-test.js
+++ b/test/root-test.js
@@ -42,21 +42,21 @@ describe('freezone', ()=>{
 
     it('cooldown', async ()=>{
         const commitment = await getCommitment(b32('zone1'), zone1)
-        await fail('ErrPending', rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await fail('ErrPending', rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
         await wait(hh, 60 * 60 * 30)
-        await fail('ErrPending', rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await fail('ErrPending', rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
         await wait(hh, 60 * 60)
-        await send(rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await send(rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
     })
 
     it('fee', async ()=>{
         await wait(hh, delay_period)
         const aliStartBalance = await ali.getBalance()
         const commitment = await getCommitment(b32('zone1'), zone1)
-        await fail('ErrPayment', rootzone.mark, commitment)
-        await fail('ErrPayment', rootzone.mark, commitment, { value: ethers.utils.parseEther('0.9') })
-        await fail('ErrPayment', rootzone.mark, commitment, { value: ethers.utils.parseEther('1.1') })
-        await send(rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await fail('ErrPayment', rootzone.hark, commitment)
+        await fail('ErrPayment', rootzone.hark, commitment, { value: ethers.utils.parseEther('0.9') })
+        await fail('ErrPayment', rootzone.hark, commitment, { value: ethers.utils.parseEther('1.1') })
+        await send(rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
         const aliEndBalance = await ali.getBalance()
         want((aliStartBalance.sub(ethers.utils.parseEther('1.0'))).gt(aliEndBalance)).true
         want((aliStartBalance.sub(ethers.utils.parseEther('1.5'))).lt(aliEndBalance)).true
@@ -65,7 +65,7 @@ describe('freezone', ()=>{
     it('etch fail wrong hash', async ()=>{
         await wait(hh, delay_period)
         const commitment = await getCommitment(b32('zone1'), zone1)
-        await send(rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await send(rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
         await fail('ErrExpired', rootzone.etch, b32('wrong_salt'), b32('zone1'), zone1)
         await send(rootzone.etch, b32('salt'), b32('zone1'), zone1)
     })
@@ -73,18 +73,18 @@ describe('freezone', ()=>{
     it('etch fail rewrite zone', async ()=>{
         await wait(hh, delay_period)
         const commitment = await getCommitment(b32('free'), zone1)
-        await send(rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await send(rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
         await fail('revert', rootzone.etch, b32('salt'), b32('free'), zone1)
     })
 
     it('state updates', async ()=>{
         await wait(hh, delay_period)
         const commitment = await getCommitment(b32('zone1'), zone1)
-        await send(rootzone.mark, commitment, { value: ethers.utils.parseEther('1') })
+        await send(rootzone.hark, commitment, { value: ethers.utils.parseEther('1') })
 
         await wait(hh, delay_period)
         const newCommitment = await getCommitment(b32('zone2'), zone2)
-        await send(rootzone.mark, newCommitment, { value: ethers.utils.parseEther('1') })
+        await send(rootzone.hark, newCommitment, { value: ethers.utils.parseEther('1') })
 
         await fail('ErrExpired', rootzone.etch, b32('salt'), b32('zone1'), zone1)
         await send(rootzone.etch, b32('salt'), b32('zone2'), zone2)


### PR DESCRIPTION
These names suggested switching the order
Switching the order and switching the names makes these issues more clear:
https://github.com/dapphub/dmap/issues/23
https://github.com/dapphub/dmap/pull/22#discussion_r822587696

Then we would have:
```
slot0 (meta)    [flags --> ... <-- content metadata / cid prefix etc]
slot1 (data)    [hash]
```
Which is natural to interpret as:
```
[flags   ...  <00><prefix>]<hash>]
==
[flags ... <00><prefix><hash>]
```