### PR TITLE
ipfs connection to local or embedded node

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -24,9 +24,6 @@
 
 <div id="result"></div>
 
-<!--<script defer src="dependencies.js" crossorigin="no-cors"></script>-->
-<!--<script defer src="main.js"></script>-->
-
 <script defer src="dependencies.js"></script>
 <script defer src="main.js"></script>
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -12,15 +12,24 @@
   #result {
       white-space: pre;
   }
-
+  #localNode {
+      width: 210px;
+  }
 </style>
 </head>
 <body>
 <h1>dmap</h1>
 
-<label for="dpath">dmap://</label>
-<input type="text" id="dpath" name="dpath" value="free.weth">
-<input type="button" id="btnGet" value="Get">
+<div>
+    <label for="localNode">ipfs node</label>
+    <input type="text" id="localNode" name="localNode" value="/ip4/127.0.0.1/tcp/5001" title="optional">
+</div>
+
+<div>
+    <label for="dpath">dmap://</label>
+    <input type="text" id="dpath" name="dpath" value="free.weth">
+    <input type="button" id="btnGet" value="Get">
+</div>
 
 <div id="result"></div>
 

--- a/package.json
+++ b/package.json
@@ -11,16 +11,13 @@
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@types/mocha": "^9.0.0",
     "hardhat": "^2.8.3",
-    "ipfs-core": "^0.14.2",
     "ipfs-http-client": "^56.0.2",
-    "ipfs-provider": "^2.1.0",
     "minihat": "^0.0.5",
     "web3-utils": "^1.7.1",
     "webpack": "^5.70.0",
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "ebnf": "^1.9.0",
-    "node-polyfill-webpack-plugin": "^1.1.4"
+    "ebnf": "^1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@types/mocha": "^9.0.0",
     "hardhat": "^2.8.3",
+    "ipfs-core": "^0.14.2",
+    "ipfs-http-client": "^56.0.2",
+    "ipfs-provider": "^2.1.0",
     "minihat": "^0.0.5",
-    "v8": "^0.1.0",
     "web3-utils": "^1.7.1",
     "webpack": "^5.70.0",
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "ebnf": "^1.9.0"
+    "ebnf": "^1.9.0",
+    "node-polyfill-webpack-plugin": "^1.1.4"
   }
 }

--- a/view/app.js
+++ b/view/app.js
@@ -1,26 +1,51 @@
 import { ethers } from 'ethers'
-const { getIpfs, providers } = require('ipfs-provider')
-const { httpClient, jsIpfs } = providers
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
 const dmap = require('../dmap.js')
 const dmapAddress = '0x7fA88e1014B0640833a03ACfEC71F242b5fBDC85'
 const dmapArtifact = require('../artifacts/core/dmap.sol/Dmap.json')
+const IPFS = require('ipfs-http-client')
+
+const gateways = ['https://ipfs.fleek.co/ipfs/',
+                  'https://gateway.pinata.cloud/ipfs/',
+                  'https://cloudflare-ipfs.com/ipfs/',
+                  'https://storry.tv/ipfs/',
+                  'https://ipfs.io/ipfs/',
+                  'https://hub.textile.io/ipfs/']
+
+const resolveCID = async (cid, targetDigest, nodeAddress) => {
+    const verify = async bytes => {
+        const hash = await sha256.digest(bytes)
+        const resultDigest = JSON.stringify(hash.digest)
+        return targetDigest === resultDigest
+    }
+    const node = IPFS.create(nodeAddress)
+    const catResponse = await node.cat(cid)
+    // initially handle only single chunk verification and sha256
+    try {
+        const chunk = await catResponse.next()
+        if(await verify(chunk.value)) {
+            return chunk.value
+        }
+    } catch(e) {}
+
+    for (const gateway of gateways) {
+        const url = gateway + cid
+        try {
+            const response = await fetch(url);
+            const reader = response.body.getReader();
+            let readRes = await reader.read();
+            if (await verify(readRes.value)) {
+                return readRes.value
+            }
+        } catch (e) {}
+    }
+    throw 'unable to resolve cid'
+}
 
 window.onload = async() => {
     const $ = document.querySelector.bind(document);
     const line =s=> { $('#result').textContent += s + '\n' }
-    const node = await getIpfs({
-        providers: [
-            // attempt to use local node, if unsuccessful fallback to running embedded core js-ipfs in-page
-            httpClient({
-                loadHttpClientModule: () => require('ipfs-http-client'),
-                apiAddress: '/ip4/127.0.0.1/tcp/5001'
-            }),
-            jsIpfs({
-                loadJsIpfsModule: () => require('ipfs-core'),
-                options: { }
-            })
-        ]
-    })
 
     $('#btnGet').addEventListener('click', async () =>  {
         const dpath = $('#dpath').value;
@@ -45,21 +70,17 @@ window.onload = async() => {
 
         try {
             // display ipfs content from a CID if we can, otherwise display as text
-            const cidResult = dmap.unpackCID(walkResult.meta, walkResult.data)
-            line(`ipfs: ${cidResult}`)
-            const ipfsResult = await node.ipfs.cat(cidResult)
-            let s = ''
+            const cid = dmap.unpackCID(walkResult.meta, walkResult.data)
+            line(`ipfs: ${cid}`)
+            const targetDigest = JSON.stringify(CID.parse(cid).multihash.digest)
+            const resolved = await resolveCID(cid, targetDigest, $('#localNode').value)
             let utf8decoder = new TextDecoder()
-            for await (const chunk of ipfsResult) {
-                s += utf8decoder.decode(chunk)
-            }
-            line(s)
+            line(utf8decoder.decode(resolved))
         }
         catch(e){
             let utf8decoder = new TextDecoder()
             const bytes = Buffer.from(walkResult.data.slice(2), 'hex')
-            let i
-            for (i = 0; i < bytes.length; i++) {
+            for (var i = 0; i < bytes.length; i++) {
                 if (bytes[bytes.length -1 - i] !== 0) {
                     break
                 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
     mode: 'production',
@@ -9,6 +10,12 @@ module.exports = {
         path: path.resolve(__dirname, 'dist'),
         filename: '[name].js',
     },
+    plugins: [
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer'],
+            process: 'process/browser'
+        })
+    ],
     optimization: {
         minimize: false,
         splitChunks: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,6 @@ module.exports = {
     plugins: [
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
-            process: 'process/browser'
         })
     ],
     optimization: {


### PR DESCRIPTION
There's no simple way of connecting to a browsers IPFS interface, it was removed https://github.com/ipfs/ipfs-companion/pull/777 and not replaced.

This change makes it easy for anyone to use the app. It should just work without resorting to a gateway or requiring users to manually set up a node and set correct access control config. If they have a local node running configured for CORS it will use that, and otherwise create a core js-ipfs node in page.