### PR TITLE
fix hardhat ethers incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
     "@etherpacks/dpack": "^0.0.29",
-    "@nomiclabs/hardhat-ethers": "^2.0.5",
+    "@nomiclabs/hardhat-ethers": "2.0.6",
     "@types/mocha": "^9.0.0",
-    "hardhat": "^2.8.3",
+    "hardhat": "^2.9.4",
     "minihat": "^0.0.5",
     "web3-utils": "^1.7.1",
     "webpack": "^5.70.0",


### PR DESCRIPTION
walk and getStorageAt are currently broken if packages have the most recent hardhat, 2.9.5. 

The pinned versions here are the latest hardhat-ethers and second most recent hardhat.

> hardhat-ethers 2.0.6 strips the zeros in index.ts:hexValue(), and hardhat 2.9.5 changed the type of slot from quantity to Storageslot. The Storageslot validation function requires all the leading zeros so getStorageAt() always fails.

An issue has been raised, https://github.com/NomicFoundation/hardhat/issues/2709