### PR TITLE
Setup Repo for Foundry Fuzzing Tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/ds-test"]
+	path = lib/ds-test
+	url = https://github.com/dapphub/ds-test

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,6 @@
+[default]
+src = 'foundry_tests'
+out = 'out'
+libs = ['lib']
+fuzz_runs = 1
+# See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/foundry_tests/test/README.md
+++ b/foundry_tests/test/README.md
@@ -1,0 +1,14 @@
+## Fuzz Tests against deployed dmap object
+The tests fork mainnet and run tests against the deployed dmap object.
+
+To run them, go to the root of the repo and do:
+```
+forge install
+```
+
+Then do
+```
+forge test -f <YOUR RPC URL> test
+```
+
+optionally pass `-vvvv` to see fork and call details


### PR DESCRIPTION
Add the setup files for running fuzz tests against mainnet fork using foundry. Will be followed by a supplemental PRs with tests.

All existing NPM tests passing.